### PR TITLE
Arreglado el fallo de el GeckoDriver con FIrefox

### DIFF
--- a/notebooks/scraping/scraping-2-0-selenium.ipynb
+++ b/notebooks/scraping/scraping-2-0-selenium.ipynb
@@ -92,6 +92,46 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Se a variable de entorno non nola recoñece importaremos estas dúas librarías e en vez de executar o driver engadirémoslle dous parámetros, a ruta a onde temos o driver e o executábel de firefox. (Aseguradevos de ter instalado firefox)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from selenium.webdriver.firefox.service import Service\n",
+    "from selenium.webdriver.firefox.options import Options"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Especifica a ruta ao GeckoDriver\n",
+    "gecko_driver_path = 'C:/Users/{nombre.apellido}/bin/geckodriver.exe'\n",
+    "\n",
+    "\n",
+    "# Especifica a ruta ao executábel de Firefox\n",
+    "firefox_binary_path = 'C:/Program Files/Mozilla Firefox/firefox.exe'\n",
+    "\n",
+    "# Crea un obxecto Options e establece a ruta ao executábel de Firefox\n",
+    "options = Options()\n",
+    "options.binary_location = firefox_binary_path\n",
+    "\n",
+    "\n",
+    "# Crea un obxecto Service coa ruta ao GeckoDriver\n",
+    "service = Service(executable_path=gecko_driver_path)\n",
+    "driver = webdriver.Firefox(service=service, options=options)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Importar as dependencias de selenium"
    ]
   },


### PR DESCRIPTION
**ERROR: No se pudo encontrar el driver / No se pudo encontrar la ruta al Firefox**

Primero Instalaremos el Firefox, especificamos la ruta absoluta tanto del Driver como del binario de Firefox y se las pasamos como parámetros al llamar al webdriver. 